### PR TITLE
Add tiny frontend ssr config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiny-frontend/client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiny-frontend/client",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@ungap/global-this": "^0.4.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiny-frontend/client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "license": "MIT",
   "scripts": {
     "dev": "vite",

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,3 +9,9 @@ export interface TinyFrontendModuleConfig {
   umdBundle: string;
   cssBundle?: string;
 }
+
+export interface TinyFrontendSsrConfig {
+  jsBundle: string;
+  moduleConfigScript: string;
+  cssBundle?: string;
+}


### PR DESCRIPTION
Changes `loadTinyFrontendServer` to return a `tinyFrontendSsrConfig`
property that can be used on consumers as an alternative to `tinyFrontendStringToAddToSsrResult`