### PR TITLE
feature: no client eval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiny-frontend/client",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiny-frontend/client",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "license": "MIT",
   "scripts": {
     "dev": "vite",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,15 +1,19 @@
 export class TinyClientFetchError extends Error {
-  constructor(libraryName: string, libraryVersion: string, message: string) {
+  constructor(
+    tinyFrontendName: string,
+    contractVersion: string,
+    message: string
+  ) {
     super(
-      `Failed to fetch tiny frontend ${libraryName} version ${libraryVersion} from API, ${message}`
+      `Failed to fetch tiny frontend ${tinyFrontendName} version ${contractVersion} from API, ${message}`
     );
     this.name = "TinyClientFetchError";
   }
 }
 
 export class TinyClientLoadBundleError extends Error {
-  constructor(libraryName: string) {
-    super(`Failed to load script for tiny frontend ${libraryName}`);
+  constructor(tinyFrontendName: string) {
+    super(`Failed to load script for tiny frontend ${tinyFrontendName}`);
     this.name = "TinyClientLoadBundleError";
   }
 }

--- a/src/load.client.ts
+++ b/src/load.client.ts
@@ -1,7 +1,7 @@
 import { TinyClientLoadBundleError } from "./errors";
 import { LoadTinyFrontendOptions, TinyFrontendModuleConfig } from "./types";
 import { getTinyFrontendModuleConfig } from "./utils/getTinyFrontendModuleConfig";
-import { loadUmdBundle } from "./utils/loadUmdBundle";
+import { loadUmdBundleClientWithCache } from "./utils/loadUmdBundle";
 
 export const loadTinyFrontendClient = async <T>({
   name,
@@ -19,8 +19,8 @@ export const loadTinyFrontendClient = async <T>({
   const tinyFrontendModuleConfig =
     tinyFrontendModuleConfigFromSsr ??
     (await getTinyFrontendModuleConfig({
-      libraryName: name,
-      libraryVersion: contractVersion,
+      tinyFrontendName: name,
+      contractVersion,
       hostname: tinyApiEndpoint,
       retryPolicy,
       cacheTtlInMs,
@@ -37,8 +37,9 @@ export const loadTinyFrontendClient = async <T>({
   }
 
   try {
-    return await loadUmdBundle({
+    return await loadUmdBundleClientWithCache({
       bundleUrl: `${tinyApiEndpoint}/tiny/bundle/${tinyFrontendModuleConfig.umdBundle}`,
+      tinyFrontendName: name,
       dependenciesMap,
       baseCacheKey: `${name}-${contractVersion}`,
       retryPolicy,

--- a/src/load.server.ts
+++ b/src/load.server.ts
@@ -3,7 +3,7 @@ import "@ungap/global-this";
 import { TinyClientLoadBundleError } from "./errors";
 import { LoadTinyFrontendOptions, TinyFrontendSsrConfig } from "./types";
 import { getTinyFrontendModuleConfig } from "./utils/getTinyFrontendModuleConfig";
-import { loadUmdBundle } from "./utils/loadUmdBundle";
+import { loadUmdBundleServerWithCache } from "./utils/loadUmdBundle";
 
 export interface TinyFrontendServerResponse<T> {
   tinyFrontend: T;
@@ -21,8 +21,8 @@ export const loadTinyFrontendServer = async <T>({
   const { retryPolicy, cacheTtlInMs = 2 * 60 * 1_000 } = loadingOptions;
 
   const tinyFrontendModuleConfig = await getTinyFrontendModuleConfig({
-    libraryName: name,
-    libraryVersion: contractVersion,
+    tinyFrontendName: name,
+    contractVersion,
     hostname: tinyApiEndpoint,
     retryPolicy,
     cacheTtlInMs,
@@ -34,8 +34,9 @@ export const loadTinyFrontendServer = async <T>({
     : undefined;
 
   try {
-    const tinyFrontend = await loadUmdBundle<T>({
+    const tinyFrontend = await loadUmdBundleServerWithCache<T>({
       bundleUrl: umdBundleUrl,
+      tinyFrontendName: name,
       dependenciesMap,
       baseCacheKey: `${name}-${contractVersion}`,
       retryPolicy,
@@ -47,7 +48,7 @@ export const loadTinyFrontendServer = async <T>({
 
     const tinyFrontendStringToAddToSsrResult = `
 ${cssBundleUrl ? `<link rel="stylesheet" href="${cssBundleUrl}">` : ""}
-<link rel="preload" href="${umdBundleUrl}" as="fetch" crossorigin="anonymous">
+<link rel="preload" href="${umdBundleUrl}" crossorigin="anonymous">
 <script>${moduleConfigScript}</script>`;
 
     const tinyFrontendSsrConfig: TinyFrontendSsrConfig = {

--- a/src/load.server.ts
+++ b/src/load.server.ts
@@ -48,7 +48,7 @@ export const loadTinyFrontendServer = async <T>({
 
     const tinyFrontendStringToAddToSsrResult = `
 ${cssBundleUrl ? `<link rel="stylesheet" href="${cssBundleUrl}">` : ""}
-<link rel="preload" href="${umdBundleUrl}" crossorigin="anonymous">
+<link rel="preload" href="${umdBundleUrl}" as="script" crossorigin="anonymous">
 <script>${moduleConfigScript}</script>`;
 
     const tinyFrontendSsrConfig: TinyFrontendSsrConfig = {

--- a/src/utils/getTinyFrontendModuleConfig.test.ts
+++ b/src/utils/getTinyFrontendModuleConfig.test.ts
@@ -26,8 +26,8 @@ describe("[getTinyFrontendModuleConfig]", () => {
     );
 
     const tinyFrontendModuleConfig = await getTinyFrontendModuleConfig({
-      libraryName: "MOCK_LIB_NAME",
-      libraryVersion: "MOCK_LIB_VERSION",
+      tinyFrontendName: "MOCK_LIB_NAME",
+      contractVersion: "MOCK_LIB_VERSION",
       hostname: "https://mock.hostname/api",
     });
 
@@ -53,8 +53,8 @@ describe("[getTinyFrontendModuleConfig]", () => {
 
     await expect(
       getTinyFrontendModuleConfig({
-        libraryName: "MOCK_LIB_NAME",
-        libraryVersion: "MOCK_LIB_VERSION",
+        tinyFrontendName: "MOCK_LIB_NAME",
+        contractVersion: "MOCK_LIB_VERSION",
         hostname: "https://mock.hostname/api",
       })
     ).rejects.toEqual(
@@ -75,8 +75,8 @@ describe("[getTinyFrontendModuleConfig]", () => {
 
     await expect(
       getTinyFrontendModuleConfig({
-        libraryName: "MOCK_LIB_NAME",
-        libraryVersion: "MOCK_LIB_VERSION",
+        tinyFrontendName: "MOCK_LIB_NAME",
+        contractVersion: "MOCK_LIB_VERSION",
         hostname: "https://mock.hostname/api",
       })
     ).rejects.toEqual(
@@ -108,8 +108,8 @@ describe("[getTinyFrontendModuleConfig]", () => {
     );
 
     const tinyFrontendModuleConfig = await getTinyFrontendModuleConfig({
-      libraryName: "MOCK_LIB_NAME",
-      libraryVersion: "MOCK_LIB_VERSION",
+      tinyFrontendName: "MOCK_LIB_NAME",
+      contractVersion: "MOCK_LIB_VERSION",
       hostname: "https://mock.hostname/api",
       retryPolicy: {
         maxRetries: 1,
@@ -125,8 +125,8 @@ describe("[getTinyFrontendModuleConfig]", () => {
 
   describe("when using cache", () => {
     const mockGetTinyFrontendModuleConfigProps = {
-      libraryName: "MOCK_LIB_NAME",
-      libraryVersion: "MOCK_LIB_VERSION",
+      tinyFrontendName: "MOCK_LIB_NAME",
+      contractVersion: "MOCK_LIB_VERSION",
       hostname: "https://mock.hostname/api",
     };
 

--- a/src/utils/getTinyFrontendModuleConfig.ts
+++ b/src/utils/getTinyFrontendModuleConfig.ts
@@ -27,8 +27,8 @@ export const moduleConfigPromiseCacheMap = new Map<
 >();
 
 export const getTinyFrontendModuleConfig = async ({
-  libraryName,
-  libraryVersion,
+  tinyFrontendName,
+  contractVersion,
   hostname,
   retryPolicy = {
     maxRetries: 0,
@@ -36,7 +36,7 @@ export const getTinyFrontendModuleConfig = async ({
   },
   cacheTtlInMs,
 }: GetTinyFrontendModuleConfigProps): Promise<TinyFrontendModuleConfig> => {
-  const cacheKey = `${libraryName}-${libraryVersion}-${hostname}`;
+  const cacheKey = `${tinyFrontendName}-${contractVersion}-${hostname}`;
 
   const cacheItem = moduleConfigPromiseCacheMap.get(cacheKey);
   if (
@@ -52,8 +52,8 @@ export const getTinyFrontendModuleConfig = async ({
   const moduleConfigPromise = retry(
     () =>
       getTinyFrontendModuleConfigBase({
-        libraryName,
-        libraryVersion,
+        tinyFrontendName,
+        contractVersion: contractVersion,
         hostname,
       }),
     retryPolicy
@@ -71,36 +71,36 @@ export const getTinyFrontendModuleConfig = async ({
 };
 
 interface GetTinyFrontendModuleConfigBaseProps {
-  libraryName: string;
-  libraryVersion: string;
+  tinyFrontendName: string;
+  contractVersion: string;
   hostname: string;
   retryPolicy?: RetryPolicy;
 }
 
 const getTinyFrontendModuleConfigBase = async ({
-  libraryName,
-  libraryVersion,
+  tinyFrontendName,
+  contractVersion,
   hostname,
 }: GetTinyFrontendModuleConfigBaseProps): Promise<TinyFrontendModuleConfig> => {
   let response;
 
   try {
     response = await fetch(
-      `${hostname}/tiny/latest/${libraryName}/${libraryVersion}`,
+      `${hostname}/tiny/latest/${tinyFrontendName}/${contractVersion}`,
       { mode: "cors" }
     );
   } catch (err) {
     throw new TinyClientFetchError(
-      libraryName,
-      libraryVersion,
+      tinyFrontendName,
+      contractVersion,
       `with error: ${(err as Record<string, string>)?.message}`
     );
   }
 
   if (response.status >= 400) {
     throw new TinyClientFetchError(
-      libraryName,
-      libraryVersion,
+      tinyFrontendName,
+      contractVersion,
       `with status ${response.status} and body '${await response.text()}'`
     );
   }
@@ -111,8 +111,8 @@ const getTinyFrontendModuleConfigBase = async ({
     responseJson = await response.json();
   } catch (err) {
     throw new TinyClientFetchError(
-      libraryName,
-      libraryVersion,
+      tinyFrontendName,
+      contractVersion,
       `while getting JSON body`
     );
   }

--- a/src/utils/loadUmdBundle.test.ts
+++ b/src/utils/loadUmdBundle.test.ts
@@ -6,7 +6,10 @@ import {
 } from "msw";
 
 import { server } from "../mocks/server";
-import { loadUmdBundle, umdBundlesPromiseCacheMap } from "./loadUmdBundle";
+import {
+  loadUmdBundleServerWithCache,
+  umdBundlesPromiseCacheMap,
+} from "./loadUmdBundle";
 
 interface MockBundle {
   mockExport: string;
@@ -25,7 +28,8 @@ describe("[loadUmdBundle]", () => {
       )
     );
 
-    const umdBundle = await loadUmdBundle<MockBundle>({
+    const umdBundle = await loadUmdBundleServerWithCache<MockBundle>({
+      tinyFrontendName: "mockTinyFrontendName",
       bundleUrl: "https://mock.hostname/api/mockBundle.js",
       dependenciesMap: {},
       baseCacheKey: "bundle-1.0.0",
@@ -46,7 +50,8 @@ define(['myMockDep', 'myMockDep2'], (myMockDep, myMockDep2) => ({ mockExport: \`
       )
     );
 
-    const umdBundle = await loadUmdBundle<MockBundle>({
+    const umdBundle = await loadUmdBundleServerWithCache<MockBundle>({
+      tinyFrontendName: "mockTinyFrontendName",
       bundleUrl: "https://mock.hostname/api/mockBundle.js",
       dependenciesMap: {
         myMockDep: "MOCK_DEP",
@@ -72,7 +77,8 @@ define(['myMockDep', 'myMockDep2'], (myMockDep, myMockDep2) => ({ mockExport: \`
     );
 
     await expect(
-      loadUmdBundle<MockBundle>({
+      loadUmdBundleServerWithCache<MockBundle>({
+        tinyFrontendName: "mockTinyFrontendName",
         bundleUrl: "https://mock.hostname/api/mockBundle.js",
         dependenciesMap: {},
         baseCacheKey: "bundle-1.0.0",
@@ -99,7 +105,8 @@ define(['myMockDep', 'myMockDep2'], (myMockDep, myMockDep2) => ({ mockExport: \`
         );
 
         await expect(
-          loadUmdBundle<MockBundle>({
+          loadUmdBundleServerWithCache<MockBundle>({
+            tinyFrontendName: "mockTinyFrontendName",
             bundleUrl: "https://mock.hostname/api/mockBundle.js",
             dependenciesMap: {},
             baseCacheKey: "bundle-1.0.0",
@@ -130,7 +137,8 @@ define(['myMockDep', 'myMockDep2'], (myMockDep, myMockDep2) => ({ mockExport: \`
           })
         );
 
-        const umdBundle = await loadUmdBundle<MockBundle>({
+        const umdBundle = await loadUmdBundleServerWithCache<MockBundle>({
+          tinyFrontendName: "mockTinyFrontendName",
           bundleUrl: "https://mock.hostname/api/mockBundle.js",
           dependenciesMap: {},
           retryPolicy: {
@@ -146,7 +154,8 @@ define(['myMockDep', 'myMockDep2'], (myMockDep, myMockDep2) => ({ mockExport: \`
   });
 
   describe("when using cache", () => {
-    const mockLoadUmdBundleOptions = {
+    const mockLoadUmdBundleServerWithCacheOptions = {
+      tinyFrontendName: "mockTinyFrontendName",
       bundleUrl: "https://mock.hostname/api/mockBundle.js",
       dependenciesMap: {},
       baseCacheKey: "bundle-1.0.0",
@@ -171,8 +180,12 @@ define(['myMockDep', 'myMockDep2'], (myMockDep, myMockDep2) => ({ mockExport: \`
       describe("when called in parallel", () => {
         it("should reuse results", async () => {
           const [umdBundle1, umdBundle2] = await Promise.all([
-            loadUmdBundle<MockBundle>(mockLoadUmdBundleOptions),
-            loadUmdBundle<MockBundle>(mockLoadUmdBundleOptions),
+            loadUmdBundleServerWithCache<MockBundle>(
+              mockLoadUmdBundleServerWithCacheOptions
+            ),
+            loadUmdBundleServerWithCache<MockBundle>(
+              mockLoadUmdBundleServerWithCacheOptions
+            ),
           ]);
 
           expect(umdBundle1).toEqual({ mockExport: "Hello World" });
@@ -184,13 +197,13 @@ define(['myMockDep', 'myMockDep2'], (myMockDep, myMockDep2) => ({ mockExport: \`
 
       describe("when called in sequence", () => {
         it("should reuse results", async () => {
-          const umdBundle1 = await loadUmdBundle<MockBundle>(
-            mockLoadUmdBundleOptions
+          const umdBundle1 = await loadUmdBundleServerWithCache<MockBundle>(
+            mockLoadUmdBundleServerWithCacheOptions
           );
           expect(umdBundle1).toEqual({ mockExport: "Hello World" });
 
-          const umdBundle2 = await loadUmdBundle<MockBundle>(
-            mockLoadUmdBundleOptions
+          const umdBundle2 = await loadUmdBundleServerWithCache<MockBundle>(
+            mockLoadUmdBundleServerWithCacheOptions
           );
           expect(umdBundle2).toEqual({ mockExport: "Hello World" });
 
@@ -219,22 +232,23 @@ define(['myMockDep', 'myMockDep2'], (myMockDep, myMockDep2) => ({ mockExport: \`
             )
           );
 
-          const umdBundle1 = await loadUmdBundle<MockBundle>(
-            mockLoadUmdBundleOptions
+          const umdBundle1 = await loadUmdBundleServerWithCache<MockBundle>(
+            mockLoadUmdBundleServerWithCacheOptions
           );
           expect(umdBundle1).toEqual({ mockExport: "Hello World" });
 
-          const umdBundle2 = await loadUmdBundle<MockBundle>({
-            ...mockLoadUmdBundleOptions,
+          const umdBundle2 = await loadUmdBundleServerWithCache<MockBundle>({
+            ...mockLoadUmdBundleServerWithCacheOptions,
             bundleUrl: "https://mock.hostname/api/mockBundle2.js",
           });
           expect(umdBundle2).toEqual({ mockExport: "This is bundle2" });
 
           expect(apiCallsCount).toEqual(1);
 
-          const umdBundle1SecondTime = await loadUmdBundle<MockBundle>(
-            mockLoadUmdBundleOptions
-          );
+          const umdBundle1SecondTime =
+            await loadUmdBundleServerWithCache<MockBundle>(
+              mockLoadUmdBundleServerWithCacheOptions
+            );
           expect(umdBundle1SecondTime).toEqual({ mockExport: "Hello World" });
 
           expect(umdBundle1).not.toBe(umdBundle1SecondTime);
@@ -258,8 +272,12 @@ define(['myMockDep', 'myMockDep2'], (myMockDep, myMockDep2) => ({ mockExport: \`
             )
           );
 
-          const promise1 = loadUmdBundle<MockBundle>(mockLoadUmdBundleOptions);
-          const promise2 = loadUmdBundle<MockBundle>(mockLoadUmdBundleOptions);
+          const promise1 = loadUmdBundleServerWithCache<MockBundle>(
+            mockLoadUmdBundleServerWithCacheOptions
+          );
+          const promise2 = loadUmdBundleServerWithCache<MockBundle>(
+            mockLoadUmdBundleServerWithCacheOptions
+          );
 
           await expect(promise1).rejects.toBeDefined();
           await expect(promise2).rejects.toBeDefined();
@@ -283,10 +301,14 @@ define(['myMockDep', 'myMockDep2'], (myMockDep, myMockDep2) => ({ mockExport: \`
           );
 
           await expect(
-            loadUmdBundle<MockBundle>(mockLoadUmdBundleOptions)
+            loadUmdBundleServerWithCache<MockBundle>(
+              mockLoadUmdBundleServerWithCacheOptions
+            )
           ).rejects.toBeDefined();
           await expect(
-            loadUmdBundle<MockBundle>(mockLoadUmdBundleOptions)
+            loadUmdBundleServerWithCache<MockBundle>(
+              mockLoadUmdBundleServerWithCacheOptions
+            )
           ).rejects.toBeDefined();
 
           expect(apiCallsCount).toEqual(2);

--- a/src/utils/loadUmdBundle.ts
+++ b/src/utils/loadUmdBundle.ts
@@ -151,7 +151,11 @@ const bundleLoaderClient = async <T>({
       );
     });
     script.addEventListener("error", (event) => {
-      reject(event.error);
+      try {
+        document.head.removeChild(script);
+      } finally {
+        reject(event.error);
+      }
     });
   });
 

--- a/src/utils/loadUmdBundle.ts
+++ b/src/utils/loadUmdBundle.ts
@@ -146,15 +146,17 @@ const bundleLoaderClient = async <T>({
 
   const loadPromise = new Promise<T>((resolve, reject) => {
     script.addEventListener("load", () => {
-      resolve((window.tinyfeExports as Record<string, T>)[tinyFrontendName]);
+      resolve(
+        (window.tinyFrontendExports as Record<string, T>)[tinyFrontendName]
+      );
     });
     script.addEventListener("error", (event) => {
       reject(event.error);
     });
   });
 
-  window.tinyfeDeps = {
-    ...window.tinyfeDeps,
+  window.tinyFrontendDeps = {
+    ...window.tinyFrontendDeps,
     ...dependenciesMap,
   };
 
@@ -170,7 +172,7 @@ declare global {
   ): void;
 
   interface Window {
-    tinyfeDeps: Record<string, unknown>;
-    tinyfeExports: Record<string, unknown>;
+    tinyFrontendDeps: Record<string, unknown>;
+    tinyFrontendExports: Record<string, unknown>;
   }
 }


### PR DESCRIPTION
Use a `script` tag on client side rather than relying on eval. This solves #7.

⚠️ It is however a breaking change for existing tiny frontend.

If you update your contract to this version you need to change your `rollupExternal` and `vite.config.ts` following [this PR](https://github.com/tiny-frontend/example-tiny-frontend/pull/9/files).